### PR TITLE
Persist measure geometries and rework layer options, map move improvements

### DIFF
--- a/gwt-ol3-client/pom.xml
+++ b/gwt-ol3-client/pom.xml
@@ -8,7 +8,7 @@
   <groupId>ol</groupId>
   <artifactId>gwt-ol3-client</artifactId>
   <name>${project.artifactId}</name>
-  <version>1.0.2</version>
+  <version>1.0.3</version>
 
   <repositories>
     <repository>

--- a/gwt-ol3-client/pom.xml
+++ b/gwt-ol3-client/pom.xml
@@ -8,7 +8,7 @@
   <groupId>ol</groupId>
   <artifactId>gwt-ol3-client</artifactId>
   <name>${project.artifactId}</name>
-  <version>1.0.1</version>
+  <version>1.0.2</version>
 
   <repositories>
     <repository>

--- a/gwt-ol3-client/src/main/java/ol/OLFactory.java
+++ b/gwt-ol3-client/src/main/java/ol/OLFactory.java
@@ -781,6 +781,28 @@ public final class OLFactory {
      *
      * @param fill
      *            {@link Fill}
+     * @return {@link Style}
+     */
+    public static Style createStyle(Fill fill) {
+	return createStyle(OLFactory.<StyleOptions> createOptions().fill(fill));
+    }
+
+    /**
+     * Creates a new {@link Style} style.
+     *
+     * @param stroke
+     *            {@link Stroke}
+     * @return {@link Style}
+     */
+    public static Style createStyle(Stroke stroke) {
+        return createStyle(OLFactory.<StyleOptions> createOptions().stroke(stroke));
+    }
+
+   /**
+     * Creates a new {@link Style} style.
+     *
+     * @param fill
+     *            {@link Fill}
      * @param stroke
      *            {@link Stroke}
      * @return {@link Style}

--- a/gwt-ol3-client/src/main/java/ol/OLFactory.java
+++ b/gwt-ol3-client/src/main/java/ol/OLFactory.java
@@ -29,8 +29,11 @@ import ol.interaction.KeyboardPan;
 import ol.interaction.KeyboardZoom;
 import ol.interaction.Modify;
 import ol.layer.Image;
+import ol.layer.ImageLayerOptions;
 import ol.layer.LayerOptions;
 import ol.layer.Tile;
+import ol.layer.TileLayerOptions;
+import ol.layer.VectorLayerOptions;
 import ol.proj.Projection;
 import ol.proj.ProjectionOptions;
 import ol.source.ImageStatic;
@@ -394,6 +397,46 @@ public final class OLFactory {
         LayerOptions options = createOptions();
         options.setSource(source);
         return options;
+    }
+
+    /**
+     * Creates {@link VectorLayerOptions} using the given
+     * {@link ol.source.Vector}.
+     *
+     * @param source
+     *            {@link ol.source.Vector}
+     * @return {@link VectorLayerOptions}
+     */
+    public static VectorLayerOptions createLayerOptionsWithSource(ol.source.Vector source) {
+	VectorLayerOptions options = createOptions();
+	options.setSource(source);
+	return options;
+    }
+
+    /**
+     * Creates {@link TileLayerOptions} using the given {@link Tile}.
+     *
+     * @param source
+     *            {@link Tile}
+     * @return {@link TileLayerOptions}
+     */
+    public static TileLayerOptions createLayerOptionsWithSource(ol.source.Tile source) {
+	TileLayerOptions options = createOptions();
+	options.setSource(source);
+	return options;
+    }
+
+    /**
+     * Creates {@link ImageLayerOptions} using the given {@link Image}.
+     *
+     * @param source
+     *            {@link Image}
+     * @return {@link ImageLayerOptions}
+     */
+    public static ImageLayerOptions createLayerOptionsWithSource(ol.source.Image source) {
+	ImageLayerOptions options = createOptions();
+	options.setSource(source);
+	return options;
     }
 
     /**

--- a/gwt-ol3-client/src/main/java/ol/OLUtil.java
+++ b/gwt-ol3-client/src/main/java/ol/OLUtil.java
@@ -1,12 +1,12 @@
 package ol;
 
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+
 import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.user.client.ui.Widget;
-
-import javax.annotation.Nullable;
-import javax.annotation.ParametersAreNonnullByDefault;
 
 import ol.event.ClickListener;
 import ol.event.DoubleClickListener;
@@ -25,6 +25,7 @@ import ol.source.TileEvent;
 import ol.source.UrlTile;
 import ol.source.Xyz;
 import ol.source.XyzOptions;
+import ol.style.Style;
 import ol.tilegrid.TileGrid;
 import ol.tilegrid.TileGridOptions;
 
@@ -147,6 +148,33 @@ public final class OLUtil {
     }-*/;
 
     /**
+     * Adds a {@link Style} to the given array of {@link Style}s.
+     *
+     * @param s
+     *            array of {@link Style}s (will be changed)
+     * @param s2
+     *            {@link Style}
+     * @return the changed array
+     */
+    public static native ol.style.Style[] addStyle(ol.style.Style[] s, ol.style.Style s2) /*-{
+		s.push(s2);
+		return s;
+    }-*/;
+
+    /**
+     * Combines two arrays of {@link Style}s.
+     *
+     * @param s
+     *            array of {@link Style}s 1
+     * @param s2
+     *            array of {@link Style}s 2
+     * @return the combined array
+     */
+    public static native ol.style.Style[] addStyles(ol.style.Style[] s, ol.style.Style[] s2) /*-{
+		return s.concat(s2);
+    }-*/;
+
+    /**
      * Adds a listener for tile loading errors.
      *
      * @param source
@@ -165,6 +193,19 @@ public final class OLUtil {
             }
         });
     }
+
+    /**
+     * Combines two {@link Style}s into an array of {@link Style}s.
+     *
+     * @param s1
+     *            {@link Style} 1
+     * @param s2
+     *            {@link Style} 2
+     * @return array of {@link Style}s
+     */
+    public static native ol.style.Style[] combineStyles(ol.style.Style s1, ol.style.Style s2) /*-{
+		return [ s1, s2 ];
+    }-*/;
 
     /**
      * Creates a JavaScript function calling the given event listener.

--- a/gwt-ol3-client/src/main/java/ol/OLUtil.java
+++ b/gwt-ol3-client/src/main/java/ol/OLUtil.java
@@ -133,20 +133,18 @@ public final class OLUtil {
         if(immediate) {
             // try to set up an event handler for the change of the view center
             // as "moveend" will be only fired when the map stops moving
-            HandlerRegistration handlerView1 = null;
             View view = map.getView();
             if(view != null) {
-                handlerView1 = OLUtil.observe(view, "change:center", new EventListener<ObjectEvent>() {
-                    @Override
-                    public void onEvent(ObjectEvent event) {
-                        // create an artificial move event
-                        Event e2 = createLinkedEvent(event, "move", (JavaScriptObject)map);
-                        MapEvent me = initMapEvent(e2, map);
-                        listener.onMapMove(me);
-                    }
-                });
-                // needs to be final to be usable in anonymous inner class
-                final HandlerRegistration handlerView = handlerView1;
+                final HandlerRegistration handlerView = OLUtil.observe(view, "change:center",
+                        new EventListener<ObjectEvent>() {
+                            @Override
+                            public void onEvent(ObjectEvent event) {
+                                // create an artificial move event
+                                Event e2 = createLinkedEvent(event, "move", (JavaScriptObject)map);
+                                MapEvent me = initMapEvent(e2, map);
+                                listener.onMapMove(me);
+                            }
+                        });
                 // return a handler registration, which detaches both event
                 // handlers
                 return new HandlerRegistration() {

--- a/gwt-ol3-client/src/main/java/ol/gwt/Measure.java
+++ b/gwt-ol3-client/src/main/java/ol/gwt/Measure.java
@@ -13,25 +13,29 @@ import ol.geom.Geometry;
 import ol.interaction.Draw;
 import ol.interaction.DrawEvent;
 import ol.interaction.DrawOptions;
+import ol.layer.VectorLayerOptions;
 import ol.style.Style;
 
 /**
  * A class for measuring like the OpenLayers 2 Measure control.
+ *
  * @author sbaumhekel
  */
 public class Measure {
 
     private com.google.gwt.user.client.EventListener chainedListener;
     private Draw draw;
+    private boolean eventListenerNeedsCleanup;
     private boolean isActive;
     private MeasureListener listener;
     private final Map map;
+    private ol.layer.Vector persistOverlay;
     private Feature sketch;
     private Style style;
-    private boolean eventListenerNeedsCleanup;
 
     /**
      * Constructs an instance.
+     *
      * @param map
      *            {@link Map} to measure on
      */
@@ -54,6 +58,7 @@ public class Measure {
 
     /**
      * Get the {@link Style} to be used for drawing the measured geometry.
+     *
      * @return {@link Style}
      */
     public Style getStyle() {
@@ -62,6 +67,7 @@ public class Measure {
 
     /**
      * Is measuring active?
+     *
      * @return true on success, else false
      */
     public boolean isActive() {
@@ -71,6 +77,7 @@ public class Measure {
     /**
      * Set the {@link Style} to be used for drawing the measured geometry.
      * Remember to set it before calling one of the start methods.
+     *
      * @param style
      *            {@link Style}
      */
@@ -80,6 +87,7 @@ public class Measure {
 
     /**
      * Start measuring using existing interaction.
+     *
      * @param type
      *            measure geometry type
      * @param listener
@@ -87,8 +95,17 @@ public class Measure {
      * @param immediate
      *            Fire events on every change to the measured geometry? If false
      *            only one event after finishing is fired. (default is true)
+     * @param persist
+     *            Keep the temporary measurement sketch drawn after the
+     *            measurement is complete. The geometry will persist until a new
+     *            measurement is started, the control is deactivated, or
+     *            {@link #stop()} is called.
      */
-    private void start(String type, MeasureListener listener, boolean immediate) {
+    private void start(String type, MeasureListener listener, boolean immediate, boolean persist) {
+
+        // clean up old instance
+        stop();
+
         this.listener = listener;
         // set up interaction
         DrawOptions drawOptions = OLFactory.createOptions();
@@ -98,6 +115,29 @@ public class Measure {
             drawOptions.style(style);
         }
         draw = OLFactory.createDraw(drawOptions);
+
+        // persist measured features?
+        if(persist) {
+            // set up overlay options
+            VectorLayerOptions voptions = OLFactory.createLayerOptionsWithSource(OLFactory.createVectorSource());
+            if(style != null) {
+                voptions.setStyle(style);
+            } else {
+                // create a default style resembling the default editing style,
+                // but adding a border to polygons
+                Style sPoly = OLFactory.createStyle(OLFactory.createFill(OLFactory.createColor(255, 255, 255, 0.5)));
+                Style sLine1 = OLFactory
+                        .createStyle(OLFactory.createStroke(OLFactory.createColor(255, 255, 255, 1), 5));
+                Style sLine2 = OLFactory.createStyle(OLFactory.createStroke(OLFactory.createColor(0, 153, 255, 1), 3));
+                // combine all styles
+                Style[] s = OLUtil.addStyle(OLUtil.combineStyles(sPoly, sLine1), sLine2);
+                voptions.setStyle(s);
+            }
+            // create an overlay and attach it to the map
+            persistOverlay = OLFactory.createVector(voptions);
+            persistOverlay.setMap(map);
+        }
+
         map.addInteraction(draw);
         // set up event handlers
         OLUtil.observe(draw, DrawEvent.DRAWSTART, new EventListener<DrawEvent>() {
@@ -106,6 +146,10 @@ public class Measure {
             public void onEvent(DrawEvent event) {
                 // remember measure feature
                 sketch = event.getFeature();
+                // clean up overlay
+                if(persistOverlay != null) {
+                    persistOverlay.<ol.source.Vector> getSource().clear(false);
+                }
             }
         });
         OLUtil.observe(draw, DrawEvent.DRAWEND, new EventListener<DrawEvent>() {
@@ -114,6 +158,10 @@ public class Measure {
             public void onEvent(DrawEvent event) {
                 // fire event and clean up
                 fireMeasureEvent();
+                // persist feature?
+                if(persistOverlay != null) {
+                    persistOverlay.<ol.source.Vector> getSource().addFeature(sketch);
+                }
                 sketch = null;
             }
         });
@@ -150,26 +198,58 @@ public class Measure {
 
     /**
      * Start measuring an area.
+     *
+     * @param listener
+     *            {@link MeasureListener}
+     */
+    public void startMeasureArea(MeasureListener listener) {
+        start(Geometry.POLYGON, listener, true, true);
+    }
+
+    /**
+     * Start measuring an area.
+     *
      * @param listener
      *            {@link MeasureListener}
      * @param immediate
      *            Fire events on every change to the measured geometry? If false
      *            only one event after finishing is fired. (default is true)
+     * @param persist
+     *            Keep the temporary measurement sketch drawn after the
+     *            measurement is complete. The geometry will persist until a new
+     *            measurement is started, the control is deactivated, or
+     *            {@link #stop()} is called.
      */
-    public void startMeasureArea(MeasureListener listener, boolean immediate) {
-        start(Geometry.POLYGON, listener, immediate);
+    public void startMeasureArea(MeasureListener listener, boolean immediate, boolean persist) {
+        start(Geometry.POLYGON, listener, immediate, persist);
     }
 
     /**
      * Start measuring a length.
+     *
+     * @param listener
+     *            {@link MeasureListener}
+     */
+    public void startMeasureLength(MeasureListener listener) {
+        start(Geometry.LINE_STRING, listener, true, true);
+    }
+
+    /**
+     * Start measuring a length.
+     *
      * @param listener
      *            {@link MeasureListener}
      * @param immediate
      *            Fire events on every change to the measured geometry? If false
      *            only one event after finishing is fired. (default is true)
+     * @param persist
+     *            Keep the temporary measurement sketch drawn after the
+     *            measurement is complete. The geometry will persist until a new
+     *            measurement is started, the control is deactivated, or
+     *            {@link #stop()} is called.
      */
-    public void startMeasureLength(MeasureListener listener, boolean immediate) {
-        start(Geometry.LINE_STRING, listener, immediate);
+    public void startMeasureLength(MeasureListener listener, boolean immediate, boolean persist) {
+        start(Geometry.LINE_STRING, listener, immediate, persist);
     }
 
     /**
@@ -186,6 +266,12 @@ public class Measure {
             map.removeInteraction(draw);
             draw = null;
         }
+        // clean up overlay
+        if(persistOverlay != null) {
+            persistOverlay.<ol.source.Vector> getSource().clear(false);
+            persistOverlay.setMap(null);
+            persistOverlay = null;
+        }
         // clean up event listener?
         if(eventListenerNeedsCleanup) {
             // try to remove chained event listener
@@ -197,5 +283,5 @@ public class Measure {
             eventListenerNeedsCleanup = false;
         }
     }
-    
+
 }

--- a/gwt-ol3-client/src/main/java/ol/layer/ImageLayerOptions.java
+++ b/gwt-ol3-client/src/main/java/ol/layer/ImageLayerOptions.java
@@ -1,0 +1,29 @@
+package ol.layer;
+
+import com.google.gwt.core.client.js.JsProperty;
+import com.google.gwt.core.client.js.JsType;
+
+import ol.Map;
+
+/**
+ * Image layer options.
+ *
+ * @author sbaumhekel
+ *
+ */
+@JsType
+public interface ImageLayerOptions extends LayerOptions {
+    /**
+     *
+     * Sets the layer as overlay on a map. The map will not manage this layer in
+     * its layers collection, and the layer will be rendered on top. This is
+     * useful for temporary layers. The standard way to add a layer to a map and
+     * have it managed by the map is to use {@link ol.Map#addLayer(Base)}.
+     *
+     * @param map
+     *            {@link Map}
+     * @return this instance
+     */
+    @JsProperty
+    ImageLayerOptions setMap(Map map);
+}

--- a/gwt-ol3-client/src/main/java/ol/layer/LayerOptions.java
+++ b/gwt-ol3-client/src/main/java/ol/layer/LayerOptions.java
@@ -3,6 +3,7 @@ package ol.layer;
 import com.google.gwt.core.client.js.JsProperty;
 import com.google.gwt.core.client.js.JsType;
 
+import ol.Extent;
 import ol.Options;
 import ol.source.Source;
 
@@ -16,6 +17,38 @@ import ol.source.Source;
 public interface LayerOptions extends Options {
 
     /**
+     * The bounding extent for layer rendering. The layer will not be rendered
+     * outside of this extent.
+     * 
+     * @param extent
+     *            extent
+     * @return this instance.
+     */
+    @JsProperty
+    LayerOptions setExtent(Extent extent);
+
+    /**
+     * The maximum resolution (exclusive) below which this layer will be
+     * visible.
+     * 
+     * @param maxResolution
+     *            maximum resolution
+     * @return this instance
+     */
+    @JsProperty
+    LayerOptions setMaxResolution(double maxResolution);
+
+    /**
+     * The minimum resolution (inclusive) at which this layer will be visible.
+     * 
+     * @param minResolution
+     *            minimum resolution
+     * @return this instance
+     */
+    @JsProperty
+    LayerOptions setMinResolution(double minResolution);
+
+    /**
      * Opacity (0, 1). Default is 1.
      * 
      * @param opacity
@@ -23,10 +56,7 @@ public interface LayerOptions extends Options {
      * @return this instance
      */
     @JsProperty
-    LayerOptions setOpacity(float opacity);
-
-    @JsProperty
-    LayerOptions setSaturation(float saturation);
+    LayerOptions setOpacity(double opacity);
 
     /**
      * Source for this layer. Required.
@@ -48,4 +78,14 @@ public interface LayerOptions extends Options {
     @JsProperty
     LayerOptions setVisible(boolean visible);
 
+    /**
+     * The z-index for layer rendering. At rendering time, the layers will be
+     * ordered, first by Z-index and then by position. The default Z-index is 0.
+     * 
+     * @param zIndex
+     *            z-index
+     * @return this instance
+     */
+    @JsProperty
+    LayerOptions setZIndex(int zIndex);
 }

--- a/gwt-ol3-client/src/main/java/ol/layer/TileLayerOptions.java
+++ b/gwt-ol3-client/src/main/java/ol/layer/TileLayerOptions.java
@@ -1,0 +1,50 @@
+package ol.layer;
+
+import com.google.gwt.core.client.js.JsProperty;
+import com.google.gwt.core.client.js.JsType;
+
+import ol.Map;
+
+/**
+ * Tile layer options.
+ *
+ * @author sbaumhekel
+ *
+ */
+@JsType
+public interface TileLayerOptions extends LayerOptions {
+    /**
+     *
+     * Sets the layer as overlay on a map. The map will not manage this layer in
+     * its layers collection, and the layer will be rendered on top. This is
+     * useful for temporary layers. The standard way to add a layer to a map and
+     * have it managed by the map is to use {@link ol.Map#addLayer(Base)}.
+     *
+     * @param map
+     *            {@link Map}
+     * @return this instance
+     */
+    @JsProperty
+    TileLayerOptions setMap(Map map);
+
+    /**
+     * Preload. Load low-resolution tiles up to preload levels. By default
+     * preload is 0, which means no preloading.
+     * 
+     * @param preload
+     *            preload levels
+     * @return this instance
+     */
+    @JsProperty
+    TileLayerOptions setPreLoad(int preload);
+
+    /**
+     * Use interim tiles on error. Default is true.
+     * 
+     * @param useInterimTilesOnError
+     *            use interim tiles on error?
+     * @return this instance
+     */
+    @JsProperty
+    TileLayerOptions setUseInterimTilesOnError(boolean useInterimTilesOnError);
+}

--- a/gwt-ol3-client/src/main/java/ol/layer/VectorLayerOptions.java
+++ b/gwt-ol3-client/src/main/java/ol/layer/VectorLayerOptions.java
@@ -1,0 +1,91 @@
+package ol.layer;
+
+import com.google.gwt.core.client.js.JsProperty;
+import com.google.gwt.core.client.js.JsType;
+
+import ol.Map;
+import ol.style.Style;
+
+/**
+ * Vector layer options.
+ *
+ * @author sbaumhekel
+ *
+ */
+@JsType
+public interface VectorLayerOptions extends LayerOptions {
+    /**
+     *
+     * Sets the layer as overlay on a map. The map will not manage this layer in
+     * its layers collection, and the layer will be rendered on top. This is
+     * useful for temporary layers. The standard way to add a layer to a map and
+     * have it managed by the map is to use {@link ol.Map#addLayer(Base)}.
+     *
+     * @param map
+     *            {@link Map}
+     * @return this instance
+     */
+    @JsProperty
+    VectorLayerOptions setMap(Map map);
+
+    /**
+     * The buffer around the viewport extent used by the renderer when getting
+     * features from the vector source for the rendering or hit-detection.
+     * Recommended value: the size of the largest symbol, line width or label.
+     * Default is 100 pixels.
+     *
+     * @param renderBuffer
+     *            render buffer
+     * @return this instance
+     */
+    @JsProperty
+    VectorLayerOptions setRenderBuffer(double renderBuffer);
+
+    /**
+     * Layer style. See ol.style for default style which will be used if this is
+     * not defined.
+     *
+     * @param style
+     *            {@link Style}
+     * @return this instance
+     */
+    @JsProperty
+    VectorLayerOptions setStyle(Style style);
+
+    /**
+     * Layer style. See ol.style for default style which will be used if this is
+     * not defined.
+     *
+     * @param style
+     *            {@link Style}
+     * @return this instance
+     */
+    @JsProperty
+    VectorLayerOptions setStyle(Style[] style);
+
+    /**
+     * When set to true, feature batches will be recreated during animations.
+     * This means that no vectors will be shown clipped, but the setting will
+     * have a performance impact for large amounts of vector data. When set to
+     * false, batches will be recreated when no animation is active. Default is
+     * false.
+     *
+     * @param updateWhileAnimating
+     *            update while animating?
+     * @return this instance
+     */
+    @JsProperty
+    VectorLayerOptions setUpdateWhileAnimating(boolean updateWhileAnimating);
+
+    /**
+     * When set to true, feature batches will be recreated during interactions.
+     * See also updateWhileAnimating. Default is false.
+     *
+     * @param updateWhileInteracting
+     *            update while interacting?
+     * @return this instance
+     */
+    @JsProperty
+    VectorLayerOptions setUpdateWhileInteracting(boolean updateWhileInteracting);
+
+}

--- a/gwt-ol3-demo/pom.xml
+++ b/gwt-ol3-demo/pom.xml
@@ -6,14 +6,14 @@
   <parent>
     <groupId>de.desjardins.ol3</groupId>
     <artifactId>gwt-ol3</artifactId>
-    <version>1.0.1</version>
+    <version>1.0.2</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>
   <groupId>ol</groupId>
   <artifactId>gwt-ol3-demo</artifactId>
   <packaging>war</packaging>
-  <version>1.0.1</version>
+  <version>1.0.2</version>
   <name>${project.artifactId}</name>
 
  <repositories>

--- a/gwt-ol3-demo/pom.xml
+++ b/gwt-ol3-demo/pom.xml
@@ -6,14 +6,14 @@
   <parent>
     <groupId>de.desjardins.ol3</groupId>
     <artifactId>gwt-ol3</artifactId>
-    <version>1.0.2</version>
+    <version>1.0.3</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>
   <groupId>ol</groupId>
   <artifactId>gwt-ol3-demo</artifactId>
   <packaging>war</packaging>
-  <version>1.0.2</version>
+  <version>1.0.3</version>
   <name>${project.artifactId}</name>
 
  <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <groupId>de.desjardins.ol3</groupId>
   <artifactId>gwt-ol3</artifactId>
   <packaging>pom</packaging>
-  <version>1.0.1</version>
+  <version>1.0.2</version>
   <name>${project.artifactId}</name>
 
   <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <groupId>de.desjardins.ol3</groupId>
   <artifactId>gwt-ol3</artifactId>
   <packaging>pom</packaging>
-  <version>1.0.2</version>
+  <version>1.0.3</version>
   <name>${project.artifactId}</name>
 
   <repositories>


### PR DESCRIPTION
Enhancement for measure control: allow geometries to persist.
After the measuring finished, the measured geometries are shown on the map overlay until `stop` is called or a new measurement is started.
In the existing version the geometry is hidden after the current measuring has been finished.
This option can be disabled.

Missing functions were added to layer options, new classes were added for these options and typed functions in `OLFactory` to create the according layer options for a given source instance.

It is now possible to catch map movements while they occur, not only after the map has finished moving.