### PR TITLE
Super dev mode prerequisites cleanup

### DIFF
--- a/gwt-ol3-client/pom.xml
+++ b/gwt-ol3-client/pom.xml
@@ -8,7 +8,7 @@
   <groupId>ol</groupId>
   <artifactId>gwt-ol3-client</artifactId>
   <name>${project.artifactId}</name>
-  <version>1.0.3</version>
+  <version>1.0.4</version>
 
   <repositories>
     <repository>

--- a/gwt-ol3-client/src/main/java/GwtOL3.gwt.xml
+++ b/gwt-ol3-client/src/main/java/GwtOL3.gwt.xml
@@ -6,8 +6,4 @@
 
   <source path='ol'/>
 
-  <!-- allow Super Dev Mode -->
-  <add-linker name="xsiframe"/>
-  <set-configuration-property name="devModeRedirectEnabled" value="true"/>
-  <set-property name="compiler.useSourceMaps" value="true" />
 </module>

--- a/gwt-ol3-demo/pom.xml
+++ b/gwt-ol3-demo/pom.xml
@@ -6,14 +6,14 @@
   <parent>
     <groupId>de.desjardins.ol3</groupId>
     <artifactId>gwt-ol3</artifactId>
-    <version>1.0.3</version>
+    <version>1.0.4</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>
   <groupId>ol</groupId>
   <artifactId>gwt-ol3-demo</artifactId>
   <packaging>war</packaging>
-  <version>1.0.3</version>
+  <version>1.0.4</version>
   <name>${project.artifactId}</name>
 
  <repositories>

--- a/gwt-ol3-demo/src/main/java/de/desjardins/ol3/demo/GwtOL3Playground.gwt.xml
+++ b/gwt-ol3-demo/src/main/java/de/desjardins/ol3/demo/GwtOL3Playground.gwt.xml
@@ -9,8 +9,4 @@
 
   <source path='client'/>
 
-  <!-- allow Super Dev Mode -->
-  <add-linker name="xsiframe"/>
-  <set-configuration-property name="devModeRedirectEnabled" value="true"/>
-  <set-property name="compiler.useSourceMaps" value="true" />
 </module>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <groupId>de.desjardins.ol3</groupId>
   <artifactId>gwt-ol3</artifactId>
   <packaging>pom</packaging>
-  <version>1.0.3</version>
+  <version>1.0.4</version>
   <name>${project.artifactId}</name>
 
   <repositories>


### PR DESCRIPTION
Clean up Super Dev Mode prerequisites according to http://www.gwtproject.org/articles/superdevmode.html

No special settings are necessary in the gwt.xml file as the xsiframe linker is the default for 2.7.0.
`devModeRedirectEnabled` is true by default since 2.6.0, see https://gwt.googlesource.com/gwt/+/5c141831d4ec6f1fd109fb60332aa3baa6eea03b%5E%21/

Setting `compiler.useSourceMaps` to `true` even results in warnings if a project using the library is compiled with the closure compiler enabled:

    [WARN] Incompatible options: -XenableClosureCompiler and compiler.useSourceMaps=true; ignoring compiler.useSourceMaps=true.
And that is also the main reason for this change.